### PR TITLE
fix: update Instagram profile link

### DIFF
--- a/data/about.md
+++ b/data/about.md
@@ -1,5 +1,5 @@
 Igor Kamyshev is a software engineer and an open-source contributor. I love clean code and working products. Writing code on TypeScript and JavaScript.
 
-[Telegram](https://t.me/igorkamyshev) [GitHub](https://github.com/igorkamyshev) [Twitter](https://twitter.com/kamyshev_dev) [Instagram](https://www.instagram.com/kamyshev_trip/) [LinkedIn](https://www.linkedin.com/in/igor-kamyshev-979745110/)
+[Telegram](https://t.me/igorkamyshev) [GitHub](https://github.com/igorkamyshev) [Twitter](https://twitter.com/kamyshev_dev) [Instagram](https://www.instagram.com/kamyshev.me/) [LinkedIn](https://www.linkedin.com/in/igor-kamyshev-979745110/)
 
 Part of [Effector](https://effector.dev) core-team and write articles about software engineering. Currently working on an open-source library [Farfetched](https://ff.effector.dev). Live in Serbia.


### PR DESCRIPTION
## What\n- Update Instagram link in About section to the new handle: `kamyshev.me`.\n\n## Why\n- Keep social links up to date.